### PR TITLE
Optimize Readme to make this project look less rough

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,51 @@
 # LogFox
+
+<img src="./app/src/main/res/mipmap-xxxhdpi/ic_launcher.png" width="200" />
+
 Yet another LogCat reader for Android
 
-# Download
+[![license](https://img.shields.io/github/license/F0x1d/LogFox)](./LICENSE)
+
+## Features
+
+- [Shizuku](https://shizuku.rikka.app/) (No Root) & Root support
+- Record log
+- Show crashes
+- Material You
+
+## Download
+
 <a href="https://f-droid.org/packages/com.f0x1d.logfox">
     <img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
     alt="Get it on F-Droid"
     height="80">
 </a>
 
-# Screenshots
+## Screenshots
+
 <p align="center">
-  <img src="https://github.com/F0x1d/LogFox/blob/master/screenshots/1.png?raw=true" width="30%" />
-  <img src="https://github.com/F0x1d/LogFox/blob/master/screenshots/2.png?raw=true" width="30%" />
-  <img src="https://github.com/F0x1d/LogFox/blob/master/screenshots/3.png?raw=true" width="30%" />
-  <img src="https://github.com/F0x1d/LogFox/blob/master/screenshots/4.png?raw=true" width="30%" />
-  <img src="https://github.com/F0x1d/LogFox/blob/master/screenshots/5.png?raw=true" width="30%" />
+  <img src="./screenshots/1.png" width="30%" />
+  <img src="./screenshots/2.png" width="30%" />
+  <img src="./screenshots/3.png" width="30%" />
+  <img src="./screenshots/4.png" width="30%" />
+  <img src="./screenshots/5.png" width="30%" />
 </p>
+
+## License
+
+```txt
+Copyright (C) 2022-2023 Zoteev Maksim
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LogFox
 
-<img src="./app/src/main/res/mipmap-xxxhdpi/ic_launcher.png" width="200" />
+<img src="./app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png" width="200" />
 
 Yet another LogCat reader for Android
 
@@ -11,7 +11,10 @@ Yet another LogCat reader for Android
 - [Shizuku](https://shizuku.rikka.app/) (No Root) & Root support
 - Record log
 - Show crashes
-- Material You
+- Logs recording with ability to export to ZIP with device info
+- Observing and notifying about Java/JNI crashes and ANRs with ability to export to my textbin
+- Powerful filters
+- Material You design
 
 ## Download
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 Yet another LogCat reader for Android
 
 [![license](https://img.shields.io/github/license/F0x1d/LogFox)](./LICENSE)
+[![release](https://img.shields.io/github/v/release/F0x1d/LogFox)](https://github.com/F0x1d/LogFox/releases/latest)
+
 
 ## Features
 


### PR DESCRIPTION
Optimized the readme to my liking, this is my favorite style, I hope you can refer to it.

## Preview

![image](https://github.com/F0x1d/LogFox/assets/51242302/ba7928fd-5418-46e7-a429-0e801db8b6bb)

## Template

```markdown
# AppName

<!-- Logo or banner here. -->

description

<!-- Badages here.  Examples: licenses, exchange groups, versions, stars. -->

## Features

<!-- Features here. -->

## Download

<!-- Links here-->

## Screenshots

<!-- Screenshots here. -->

## License

<!-- The LICENSE file usually consists of the template. -->

```

## My suggestions

- `#` for first level heading, `##` for second level headings, usually there should be only one first level heading. [details](https://github.com/DavidAnson/markdownlint/blob/v0.31.1/doc/md025.md)
- Add an icon or banner to give a first impression.
- Add license to protect copyright.
- Use relative paths to avoid not being able to load images when offline and bring smart hints on supported editors

