### PR TITLE
Disable NavigationBarContrast on Android 10+

### DIFF
--- a/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
@@ -91,6 +91,7 @@ class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
         }
     }
 
+    @SuppressLint("NewApi")
     override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {
         val barShown = when (destination.id) {
             R.id.setupFragment -> false
@@ -115,7 +116,6 @@ class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
                 else -> getColor(R.color.navbar_transparent_background)
             }
         } else if (gesturesAvailable) {
-            @SuppressLint("NewApi")
             window.isNavigationBarContrastEnforced = !(barShown && !isHorizontalOrientation)
         }
 

--- a/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
@@ -114,8 +114,8 @@ class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
 
                 else -> getColor(R.color.navbar_transparent_background)
             }
-        } else if (gesturesAvailable && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            // Add Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q to make lint happy.
+        } else if (gesturesAvailable) {
+            @SuppressLint("NewApi")
             window.isNavigationBarContrastEnforced = !(barShown && !isHorizontalOrientation)
         }
 

--- a/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -28,12 +29,14 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(), NavController.OnDestinationChangedListener {
+class MainActivity : BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
+    NavController.OnDestinationChangedListener {
 
     override val viewModel by viewModels<MainViewModel>()
     private lateinit var navController: NavController
 
-    private val requestNotificationPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
+    private val requestNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
 
     private var barShown = true
     private val barScene by lazy {
@@ -48,7 +51,8 @@ class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
     }
     private val changeBoundsTransition by lazy {
         ChangeBounds().apply {
-            duration = resources.getInteger(androidx.navigation.ui.R.integer.config_navAnimTime).toLong()
+            duration =
+                resources.getInteger(androidx.navigation.ui.R.integer.config_navAnimTime).toLong()
         }
     }
 
@@ -76,7 +80,11 @@ class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
                 .setTitle(R.string.no_notification_permission)
                 .setMessage(R.string.notification_permission_is_required)
                 .setCancelable(false)
-                .setPositiveButton(android.R.string.ok) { dialog, which -> requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)}
+                .setPositiveButton(android.R.string.ok) { dialog, which ->
+                    requestNotificationPermissionLauncher.launch(
+                        Manifest.permission.POST_NOTIFICATIONS
+                    )
+                }
                 .setNegativeButton(R.string.close, null)
                 .show()
 
@@ -90,7 +98,11 @@ class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
         }
     }
 
-    override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {
+    override fun onDestinationChanged(
+        controller: NavController,
+        destination: NavDestination,
+        arguments: Bundle?
+    ) {
         val barShown = when (destination.id) {
             R.id.setupFragment -> false
             R.id.logsExtendedCopyFragment -> false
@@ -113,6 +125,9 @@ class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
 
                 else -> getColor(R.color.navbar_transparent_background)
             }
+        } else if (gesturesAvailable && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // Add Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q to make lint happy.
+            window.isNavigationBarContrastEnforced = !(barShown && !isHorizontalOrientation)
         }
 
         if (this.barShown != barShown) {

--- a/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
@@ -29,14 +29,12 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
-    NavController.OnDestinationChangedListener {
+class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(), NavController.OnDestinationChangedListener {
 
     override val viewModel by viewModels<MainViewModel>()
     private lateinit var navController: NavController
 
-    private val requestNotificationPermissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
+    private val requestNotificationPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
 
     private var barShown = true
     private val barScene by lazy {
@@ -51,8 +49,7 @@ class MainActivity : BaseViewModelActivity<MainViewModel, ActivityMainBinding>()
     }
     private val changeBoundsTransition by lazy {
         ChangeBounds().apply {
-            duration =
-                resources.getInteger(androidx.navigation.ui.R.integer.config_navAnimTime).toLong()
+            duration = resources.getInteger(androidx.navigation.ui.R.integer.config_navAnimTime).toLong()
         }
     }
 
@@ -80,11 +77,7 @@ class MainActivity : BaseViewModelActivity<MainViewModel, ActivityMainBinding>()
                 .setTitle(R.string.no_notification_permission)
                 .setMessage(R.string.notification_permission_is_required)
                 .setCancelable(false)
-                .setPositiveButton(android.R.string.ok) { dialog, which ->
-                    requestNotificationPermissionLauncher.launch(
-                        Manifest.permission.POST_NOTIFICATIONS
-                    )
-                }
+                .setPositiveButton(android.R.string.ok) { dialog, which -> requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS) }
                 .setNegativeButton(R.string.close, null)
                 .show()
 
@@ -98,11 +91,7 @@ class MainActivity : BaseViewModelActivity<MainViewModel, ActivityMainBinding>()
         }
     }
 
-    override fun onDestinationChanged(
-        controller: NavController,
-        destination: NavDestination,
-        arguments: Bundle?
-    ) {
+    override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {
         val barShown = when (destination.id) {
             R.id.setupFragment -> false
             R.id.logsExtendedCopyFragment -> false

--- a/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
@@ -77,7 +77,7 @@ class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
                 .setTitle(R.string.no_notification_permission)
                 .setMessage(R.string.notification_permission_is_required)
                 .setCancelable(false)
-                .setPositiveButton(android.R.string.ok) { dialog, which -> requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS) }
+                .setPositiveButton(android.R.string.ok) { dialog, which -> requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)}
                 .setNegativeButton(R.string.close, null)
                 .show()
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="LogFoxMaterialAlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog.Centered">
         <item name="buttonBarPositiveButtonStyle">@style/LogFoxMaterialAlertDialog.Button</item>
         <item name="buttonBarNegativeButtonStyle">@style/LogFoxMaterialAlertDialog.Button</item>
@@ -19,6 +19,7 @@
         <item name="android:windowSoftInputMode">adjustResize</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
     </style>
 
     <style name="LogFoxPreferenceTheme" parent="PreferenceThemeOverlay">


### PR DESCRIPTION
![Screenshot_2023-10-09-02-52-32-598_com f0x1d logfox](https://github.com/F0x1d/LogFox/assets/51242302/3592a1a5-db08-4b40-a2ee-80edd3d3962d)
![Screenshot_2023-10-09-02-52-35-008_com f0x1d logfox](https://github.com/F0x1d/LogFox/assets/51242302/cf1fa99e-1cbf-4b49-b226-6ddb137ac8a9)

1. Disable navigation bar contrast  on Android 10+ when bar is shown.
2. Disable navigation bar contrast in BottomSheetDialog, too.