### PR TITLE
Refactor log item background to xml

### DIFF
--- a/app/src/main/java/com/f0x1d/logfox/ui/viewholder/LogViewHolder.kt
+++ b/app/src/main/java/com/f0x1d/logfox/ui/viewholder/LogViewHolder.kt
@@ -1,7 +1,6 @@
 package com.f0x1d.logfox.ui.viewholder
 
 import android.content.res.ColorStateList
-import android.graphics.drawable.GradientDrawable
 import android.view.Gravity
 import androidx.appcompat.widget.PopupMenu
 import com.f0x1d.logfox.R
@@ -76,10 +75,7 @@ class LogViewHolder(
         }
         binding.levelText.text = data.level.letter
 
-        binding.levelText.background = GradientDrawable().apply {
-            cornerRadii = floatArrayOf(0f, 0f, radius, radius, radius, radius, 0f, 0f)
-            color = ColorStateList.valueOf(data.level.backgroundColorByLevel())
-        }
+        binding.levelText.backgroundTintList = ColorStateList.valueOf(data.level.backgroundColorByLevel())
         binding.levelText.setTextColor(data.level.foregroundColorByLevel())
 
         changeExpandedAndSelected(data)

--- a/app/src/main/java/com/f0x1d/logfox/ui/viewholder/LogViewHolder.kt
+++ b/app/src/main/java/com/f0x1d/logfox/ui/viewholder/LogViewHolder.kt
@@ -1,11 +1,9 @@
 package com.f0x1d.logfox.ui.viewholder
 
 import android.content.res.ColorStateList
-import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.GradientDrawable
 import android.view.Gravity
 import androidx.appcompat.widget.PopupMenu
-import androidx.core.graphics.ColorUtils
 import com.f0x1d.logfox.R
 import com.f0x1d.logfox.adapter.LogsAdapter
 import com.f0x1d.logfox.databinding.ItemLogBinding
@@ -14,16 +12,11 @@ import com.f0x1d.logfox.extensions.logline.foregroundColorByLevel
 import com.f0x1d.logfox.model.LogLine
 import com.f0x1d.logfox.ui.viewholder.base.BaseViewHolder
 import com.f0x1d.logfox.utils.dpToPx
-import com.google.android.material.color.MaterialColors
 
 class LogViewHolder(
     binding: ItemLogBinding,
     private val copyLog: (LogLine) -> Unit
 ): BaseViewHolder<LogLine, ItemLogBinding>(binding) {
-
-    private val currentColorPrimary = MaterialColors.getColor(binding.root, com.google.android.material.R.attr.colorPrimary)
-    private val background = binding.container.background
-    private val selectedBackground = ColorDrawable(ColorUtils.blendARGB((background as ColorDrawable).color, currentColorPrimary, 0.2f))
 
     private val radius = 6.dpToPx
 
@@ -116,6 +109,6 @@ class LogViewHolder(
 
     private fun changeExpandedAndSelected(logLine: LogLine) {
         binding.logText.maxLines = if (adapter<LogsAdapter>().expandedStates.getOrElse(logLine.id) { adapter<LogsAdapter>().logsExpanded }) Int.MAX_VALUE else 1
-        binding.container.background = if (adapter<LogsAdapter>().selectedItems.contains(logLine)) selectedBackground else background
+        binding.container.isSelected = adapter<LogsAdapter>().selectedItems.contains(logLine)
     }
 }

--- a/app/src/main/res/color/item_log_background_ripple.xml
+++ b/app/src/main/res/color/item_log_background_ripple.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.16" android:color="?colorOnBackground" />
+</selector>

--- a/app/src/main/res/drawable-ldrtl/item_log_level_background.xml
+++ b/app/src/main/res/drawable-ldrtl/item_log_level_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:bottomLeftRadius="6dp"
+        android:topLeftRadius="6dp" />
+    <solid android:color="@android:color/black" />
+</shape>

--- a/app/src/main/res/drawable/item_log_background.xml
+++ b/app/src/main/res/drawable/item_log_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <color android:color="@macro/m3_comp_filled_card_container_color" />
+    </item>
+</selector>

--- a/app/src/main/res/drawable/item_log_background.xml
+++ b/app/src/main/res/drawable/item_log_background.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_selected="true">
-        <color android:color="@macro/m3_comp_filled_card_container_color" />
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/item_log_background_ripple">
+    <item android:id="@android:id/mask">
+        <color android:color="@android:color/black" />
     </item>
-</selector>
+    <item>
+        <selector>
+            <item android:state_selected="true">
+                <color android:color="@macro/m3_comp_filled_card_container_color" />
+            </item>
+        </selector>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/item_log_level_background.xml
+++ b/app/src/main/res/drawable/item_log_level_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:bottomRightRadius="6dp"
+        android:topRightRadius="6dp" />
+    <solid android:color="@android:color/black" />
+</shape>

--- a/app/src/main/res/layout/item_log.xml
+++ b/app/src/main/res/layout/item_log.xml
@@ -2,50 +2,39 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/ripple_container"
+    android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"
-    android:background="?selectableItemBackground">
+    android:background="@drawable/item_log_background">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/container"
-        android:layout_width="0dp"
+    <TextView
+        android:id="@+id/level_text"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="?android:colorBackground"
+        android:ems="1"
+        android:text="E"
+        android:gravity="center"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/log_text"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+    <TextView
+        android:id="@+id/log_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:maxLines="1"
+        android:ellipsize="end"
+        android:textColor="?android:textColorPrimary"
+        android:layout_marginTop="3dp"
+        android:layout_marginStart="3dp"
+        android:layout_marginEnd="3dp"
+        android:layout_marginBottom="3dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toEndOf="@id/level_text"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
-
-        <TextView
-            android:id="@+id/level_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:ems="1"
-            android:text="E"
-            android:gravity="center"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/log_text"
-            app:layout_constraintBottom_toBottomOf="parent" />
-
-        <TextView
-            android:id="@+id/log_text"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:maxLines="1"
-            android:ellipsize="end"
-            android:textColor="?android:textColorPrimary"
-            android:layout_marginTop="3dp"
-            android:layout_marginStart="3dp"
-            android:layout_marginEnd="3dp"
-            android:layout_marginBottom="3dp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toEndOf="@id/level_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"/>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_log.xml
+++ b/app/src/main/res/layout/item_log.xml
@@ -20,7 +20,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/log_text"
         app:layout_constraintBottom_toBottomOf="parent"
-        android:background="@drawable/item_log_level_background" />
+        android:background="@drawable/item_log_level_background"
+        tools:textColor="@android:color/white" />
 
     <TextView
         android:id="@+id/log_text"
@@ -36,6 +37,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toEndOf="@id/level_text"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="@tools:sample/lorem/random"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_log.xml
+++ b/app/src/main/res/layout/item_log.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -14,7 +14,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:ems="1"
-        android:text="E"
+        tools:text="E"
         android:gravity="center"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_log.xml
+++ b/app/src/main/res/layout/item_log.xml
@@ -19,7 +19,8 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/log_text"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:background="@drawable/item_log_level_background" />
 
     <TextView
         android:id="@+id/log_text"


### PR DESCRIPTION
I have refactored the log background and level background to xml. The level background only needs a drawable, the rest can be set dynamically using `View.setBackgroundTint`.

I also incidentally made the item click ripple work.

Since resource files can be easily rewritten, I've also incidentally fixed the problem of level backgrounds being misdirected in the rtl language.