### PR TITLE
[fix]: Temporary fix for color issues

### DIFF
--- a/app/src/main/res/values/colors_tokens.xml
+++ b/app/src/main/res/values/colors_tokens.xml
@@ -78,4 +78,17 @@
     <color name="m3_ref_palette_error95">#ffffedea</color>
     <color name="m3_ref_palette_error99">#fffffbff</color>
     <color name="m3_ref_palette_error100">#ffffffff</color>
+
+    <!-- TODO: Use real colors, not approximate colors -->
+    <color name="m3_ref_palette_neutral12">@color/m3_ref_palette_neutral10</color>
+    <color name="m3_ref_palette_neutral17">@color/m3_ref_palette_neutral_variant20</color>
+    <color name="m3_ref_palette_neutral22">@color/m3_ref_palette_neutral_variant20</color>
+    <color name="m3_ref_palette_neutral24">@color/m3_ref_palette_neutral_variant20</color>
+    <color name="m3_ref_palette_neutral4">@color/m3_ref_palette_neutral_variant0</color>
+    <color name="m3_ref_palette_neutral6">@color/m3_ref_palette_neutral0</color>
+    <color name="m3_ref_palette_neutral87">@color/m3_ref_palette_error90</color>
+    <color name="m3_ref_palette_neutral92">@color/m3_ref_palette_error95</color>
+    <color name="m3_ref_palette_neutral94">@color/m3_ref_palette_error95</color>
+    <color name="m3_ref_palette_neutral96">@color/m3_ref_palette_error95</color>
+    <color name="m3_ref_palette_neutral98">@color/m3_ref_palette_error99</color>
 </resources>

--- a/app/src/main/res/values/colors_tokens.xml
+++ b/app/src/main/res/values/colors_tokens.xml
@@ -81,14 +81,14 @@
 
     <!-- TODO: Use real colors, not approximate colors -->
     <color name="m3_ref_palette_neutral12">@color/m3_ref_palette_neutral10</color>
-    <color name="m3_ref_palette_neutral17">@color/m3_ref_palette_neutral_variant20</color>
-    <color name="m3_ref_palette_neutral22">@color/m3_ref_palette_neutral_variant20</color>
-    <color name="m3_ref_palette_neutral24">@color/m3_ref_palette_neutral_variant20</color>
-    <color name="m3_ref_palette_neutral4">@color/m3_ref_palette_neutral_variant0</color>
+    <color name="m3_ref_palette_neutral17">@color/m3_ref_palette_neutral20</color>
+    <color name="m3_ref_palette_neutral22">@color/m3_ref_palette_neutral20</color>
+    <color name="m3_ref_palette_neutral24">@color/m3_ref_palette_neutral20</color>
+    <color name="m3_ref_palette_neutral4">@color/m3_ref_palette_neutral0</color>
     <color name="m3_ref_palette_neutral6">@color/m3_ref_palette_neutral0</color>
-    <color name="m3_ref_palette_neutral87">@color/m3_ref_palette_error90</color>
-    <color name="m3_ref_palette_neutral92">@color/m3_ref_palette_error95</color>
-    <color name="m3_ref_palette_neutral94">@color/m3_ref_palette_error95</color>
-    <color name="m3_ref_palette_neutral96">@color/m3_ref_palette_error95</color>
-    <color name="m3_ref_palette_neutral98">@color/m3_ref_palette_error99</color>
+    <color name="m3_ref_palette_neutral87">@color/m3_ref_palette_neutral90</color>
+    <color name="m3_ref_palette_neutral92">@color/m3_ref_palette_neutral90</color>
+    <color name="m3_ref_palette_neutral94">@color/m3_ref_palette_neutral95</color>
+    <color name="m3_ref_palette_neutral96">@color/m3_ref_palette_neutral95</color>
+    <color name="m3_ref_palette_neutral98">@color/m3_ref_palette_neutral99</color>
 </resources>


### PR DESCRIPTION
MaterialComponents updated the color system in v1.11.0, the color changes no longer follow the elevation, and added several new NEUTRAL colors.

Because LogFox's theme color is implemented by rewriting refs, doesn't include these new colors, it will be abnormal on devices that don't support dynamic colors.

I don't know much about Material3's color system, and I had to make a temporary fix to make it appear similar to it behaves on Android 13.

---

> Translated by ERNIE Bot of Baidu：

Material Components has updated its color system in version 1.11.0, with color changes no longer following elevation and the addition of several neutral colors.

Because the theme colors of LogFox are implemented by overriding refs, and the newly added colors are not taken into account, anomalies may occur on devices that do not support dynamic colors.

I don't quite understand the color system of Material3, so I can only make a temporary fix to make it look similar to the performance on Android13.