### PR TITLE
[refactor]: delete @SuppressLint("NewApi")

### DIFF
--- a/app/src/main/java/com/f0x1d/logfox/extensions/APIExtensions.kt
+++ b/app/src/main/java/com/f0x1d/logfox/extensions/APIExtensions.kt
@@ -1,18 +1,21 @@
 package com.f0x1d.logfox.extensions
 
-import android.os.Build
+import android.os.Build.VERSION.*
+import android.os.Build.VERSION_CODES.*
+import androidx.annotation.ChecksSdkIntAtLeast
 
-val isAtLeastAndroid13 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+@get:ChecksSdkIntAtLeast(api = TIRAMISU) val isAtLeastAndroid13 = SDK_INT >= TIRAMISU
 
-val gesturesAvailable = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
-val contrastedNavBarAvailable = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
+@get:ChecksSdkIntAtLeast(api = Q) val gesturesAvailable = SDK_INT >= Q
+/* Huawei devices will return true regardless of the SDK version */
+val contrastedNavBarAvailable = SDK_INT >= O_MR1
 
-val notificationsDynamicColorAvailable = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-val notificationsChannelsAvailable = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
-val shouldRequestNotificationsPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-val startForegroundServiceAvailable = notificationsChannelsAvailable
+@get:ChecksSdkIntAtLeast(api = S) val notificationsDynamicColorAvailable = SDK_INT >= S
+@get:ChecksSdkIntAtLeast(api = O) val notificationsChannelsAvailable = SDK_INT >= O
+@get:ChecksSdkIntAtLeast(api = TIRAMISU) val shouldRequestNotificationsPermission = SDK_INT >= TIRAMISU
+@get:ChecksSdkIntAtLeast(api = O) val startForegroundServiceAvailable = notificationsChannelsAvailable
 
-val canPickJSON = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+@get:ChecksSdkIntAtLeast(api = R) val canPickJSON = SDK_INT >= R
 
-val uiModeManagerAvailable = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-val mutablePendingIntentAvailable = uiModeManagerAvailable
+@get:ChecksSdkIntAtLeast(api = S) val uiModeManagerAvailable = SDK_INT >= S
+@get:ChecksSdkIntAtLeast(api = S) val mutablePendingIntentAvailable = uiModeManagerAvailable

--- a/app/src/main/java/com/f0x1d/logfox/extensions/context/ContextExtensions.kt
+++ b/app/src/main/java/com/f0x1d/logfox/extensions/context/ContextExtensions.kt
@@ -11,7 +11,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.os.Build
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -38,6 +40,8 @@ fun Context.hasPermissionToReadLogs() = ContextCompat.checkSelfPermission(
 val Context.notificationManagerCompat get() = NotificationManagerCompat.from(this)
 val Context.notificationManager get() = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 val Context.activityManager get() = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+
+@get:RequiresApi(Build.VERSION_CODES.S)
 val Context.uiModeManager get() = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
 
 fun Context.startLoggingAndService(loggingRepository: LoggingRepository, appPreferences: AppPreferences, force: Boolean = false) {
@@ -54,7 +58,6 @@ fun Context.startLoggingAndServiceIfCan(loggingRepository: LoggingRepository, ap
     }
 }
 
-@SuppressLint("NewApi")
 fun Context.startLoggingService() {
     Intent(this, LoggingService::class.java).also {
         if (startForegroundServiceAvailable)
@@ -119,7 +122,6 @@ fun Context.doIfPermitted(block: NotificationManagerCompat.() -> Unit) = if (has
 else
     Unit
 
-@SuppressLint("NewApi")
 fun Context.applyTheme(nightMode: Int, force: Boolean = false) {
     if (uiModeManagerAvailable) {
         if (force) uiModeManager.setApplicationNightMode(

--- a/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/f0x1d/logfox/ui/activity/MainActivity.kt
@@ -117,7 +117,6 @@ class MainActivity: BaseViewModelActivity<MainViewModel, ActivityMainBinding>(),
         }
     }
 
-    @SuppressLint("NewApi")
     override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {
         val barShown = when (destination.id) {
             R.id.setupFragment -> false


### PR DESCRIPTION
NewApi lint can help developers identify potential compatibility issues. 

The previous code was disabled because the editor would report errors, as it couldn't recognize whether isAtLeastAndroid13 actually returns true only on Android 13. Now I have added ChecksSdkIntAtLeast to tell the editor to only return true if the API is Android 13 or later.