### PR TITLE
[translation]: pt-BR: translate "UI"

### DIFF
--- a/strings/src/main/res/values-pt-rBR/strings.xml
+++ b/strings/src/main/res/values-pt-rBR/strings.xml
@@ -166,4 +166,5 @@ blacklist: ignored apps
     <string name="remove_from_blacklist">Parar de ignorar app</string>
     <string name="warning_blacklist">Você tem certeza que quer ignorar esse app? O LogFox não coleta as falhas desses apps</string>
     <string name="share_logs">Compartilhar registros</string>
+    <string name="ui">Interface</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="delete">Delete</string>
     <string name="resume">Resume</string>
     <string name="foxbin" translatable="false">foxbin</string>
-    <string name="ui" translatable="false">UI</string>
+    <string name="ui">UI</string>
     <string name="logs_update_interval">Logs update interval</string>
     <string name="in_ms">In ms</string>
     <string name="this_is_not_a_number">This is not a number</string>


### PR DESCRIPTION
This string is marked as untranslatable, but UI is for user interface, it gets a bit bad to translate. Just using 'interface' here. (Yes it is the same word)