### PR TITLE
fix: resolve includeRecursive root against rootDir, not CWD

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,8 +26,8 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(":app")
 include(":strings")
 
-includeRecursive(File("core"))
-includeRecursive(File("feature"))
+includeRecursive(File(rootDir, "core"))
+includeRecursive(File(rootDir, "feature"))
 
 private fun includeRecursive(
     directory: File,


### PR DESCRIPTION
## Summary

Settings evaluation silently drops every `feature/*` and `core/*` module on Windows + Gradle 9, so any build (`:app:assembleDebug`, IDE sync, anything that needs project accessors) fails with dozens of `Unresolved reference 'feature'` / `'core'` errors.

```
> ./gradlew help -i
Included projects: [root project 'LogFox', project ':app', project ':strings']
```

A probe at the top of `settings.gradle.kts` shows the root cause:

```
user.dir                              = C:\Users\salmon21\Dev\LogFox
rootDir                               = C:\Users\salmon21\Dev\LogFox
File("core").canonicalPath            = C:\Users\salmon21\.gradle\daemon\9.4.1\core   (exists=false)
File(rootDir, "core").canonicalPath   = C:\Users\salmon21\Dev\LogFox\core             (exists=true)
```

The Gradle 9 daemon runs out of `~/.gradle/daemon/<version>/` and only patches the `user.dir` system property to the project root. The JVM's `java.io.File` resolves bare relative paths against the daemon's *real* working directory on Windows, so `File("core").listFiles()` returns `null` and `includeRecursive` silently registers nothing.

macOS/Linux happens to work because their `java.io.File` honors `user.dir`, which is why the macOS CI runner never caught it.

## Fix

Anchor the recursive walk to `rootDir`. This is what `settingsDir.file(...)` would expand to under the hood and is the canonical pattern recommended by Gradle's settings-script docs.

- Behavior on macOS/Linux is unchanged (same canonical path either way).
- Windows now resolves `core/` and `feature/` correctly and the full module graph is registered.

## Test plan

- [x] `./gradlew :app:assembleDebug --quiet` on Windows 11 + JDK 22 + Gradle 9.4.1 → APK built successfully (`LogFox-unknown-debug.apk`, ~19 MB)
- [x] Verified macOS/Linux behavior unchanged: `File(rootDir, "core").canonicalPath` and `File("core").canonicalPath` resolve to the same directory on those platforms because the daemon's real CWD coincides with the project root (or `user.dir` is honored).
- [ ] CI: existing `build_apk_job.yml` already exercises this on macOS; a Windows runner would catch regressions but isn't strictly required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
