### PR TITLE
fix: don't mark filter edit dirty on render

### DIFF
--- a/core/ui/base/src/main/kotlin/com/f0x1d/logfox/core/ui/base/ext/TextViewExt.kt
+++ b/core/ui/base/src/main/kotlin/com/f0x1d/logfox/core/ui/base/ext/TextViewExt.kt
@@ -7,25 +7,45 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 
+/**
+ * Observes user edits, attaching the watcher only while the fragment is resumed.
+ *
+ * Returns a setter that updates the text *without* notifying [callback]: programmatic updates (e.g.
+ * rendering state back into the field) would otherwise look like user edits. Use it instead of
+ * [TextView.setText] when pushing state into the field, and keep [TextView.setText] for genuine user
+ * input only.
+ */
 fun TextView.doAfterTextChanged(
     fragment: Fragment,
     callback: (Editable?) -> Unit,
-) {
+): (CharSequence?) -> Unit {
     val textWatcher = object : TextWatcher {
         override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) = Unit
         override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) = Unit
         override fun afterTextChanged(s: Editable) = callback(s)
     }
 
+    var attached = false
+
     fragment.viewLifecycleOwner.lifecycle.addObserver(
         object : DefaultLifecycleObserver {
             override fun onResume(owner: LifecycleOwner) {
                 addTextChangedListener(textWatcher)
+                attached = true
             }
 
             override fun onPause(owner: LifecycleOwner) {
                 removeTextChangedListener(textWatcher)
+                attached = false
             }
         },
     )
+
+    return { text ->
+        // Detach around the update so the watcher doesn't fire for a programmatic change, then
+        // restore whatever attachment state the lifecycle had set.
+        removeTextChangedListener(textWatcher)
+        setText(text)
+        if (attached) addTextChangedListener(textWatcher)
+    }
 }

--- a/feature/filters/presentation/src/main/kotlin/com/f0x1d/logfox/feature/filters/presentation/edit/ui/EditFilterFragment.kt
+++ b/feature/filters/presentation/src/main/kotlin/com/f0x1d/logfox/feature/filters/presentation/edit/ui/EditFilterFragment.kt
@@ -60,6 +60,15 @@ internal class EditFilterFragment :
         }
     }
 
+    // Setters that update each field without firing its text-changed callback, so rendering state
+    // back into the form is not mistaken for a user edit (which would mark the form dirty).
+    private lateinit var setUidText: (CharSequence?) -> Unit
+    private lateinit var setPidText: (CharSequence?) -> Unit
+    private lateinit var setTidText: (CharSequence?) -> Unit
+    private lateinit var setPackageNameText: (CharSequence?) -> Unit
+    private lateinit var setTagText: (CharSequence?) -> Unit
+    private lateinit var setContentText: (CharSequence?) -> Unit
+
     override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) = FragmentEditFilterBinding.inflate(inflater, container, false)
 
     override fun FragmentEditFilterBinding.onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -116,14 +125,14 @@ internal class EditFilterFragment :
             send(EditFilterCommand.Save)
         }
 
-        uidText.doAfterTextChanged(this@EditFilterFragment) { send(EditFilterCommand.UpdateUid(it?.toString().orEmpty())) }
-        pidText.doAfterTextChanged(this@EditFilterFragment) { send(EditFilterCommand.UpdatePid(it?.toString().orEmpty())) }
-        tidText.doAfterTextChanged(this@EditFilterFragment) { send(EditFilterCommand.UpdateTid(it?.toString().orEmpty())) }
-        packageNameText.doAfterTextChanged(this@EditFilterFragment) {
+        setUidText = uidText.doAfterTextChanged(this@EditFilterFragment) { send(EditFilterCommand.UpdateUid(it?.toString().orEmpty())) }
+        setPidText = pidText.doAfterTextChanged(this@EditFilterFragment) { send(EditFilterCommand.UpdatePid(it?.toString().orEmpty())) }
+        setTidText = tidText.doAfterTextChanged(this@EditFilterFragment) { send(EditFilterCommand.UpdateTid(it?.toString().orEmpty())) }
+        setPackageNameText = packageNameText.doAfterTextChanged(this@EditFilterFragment) {
             send(EditFilterCommand.UpdatePackageName(it?.toString().orEmpty()))
         }
-        tagText.doAfterTextChanged(this@EditFilterFragment) { send(EditFilterCommand.UpdateTag(it?.toString().orEmpty())) }
-        contentText.doAfterTextChanged(this@EditFilterFragment) {
+        setTagText = tagText.doAfterTextChanged(this@EditFilterFragment) { send(EditFilterCommand.UpdateTag(it?.toString().orEmpty())) }
+        setContentText = contentText.doAfterTextChanged(this@EditFilterFragment) {
             send(EditFilterCommand.UpdateContent(it?.toString().orEmpty()))
         }
     }
@@ -136,12 +145,12 @@ internal class EditFilterFragment :
             updateEnabledButton(state.enabled)
             updateTitle(state.name)
 
-            setTextIfDifferent(uidText, state.uid.orEmpty())
-            setTextIfDifferent(pidText, state.pid.orEmpty())
-            setTextIfDifferent(tidText, state.tid.orEmpty())
-            setTextIfDifferent(packageNameText, state.packageName.orEmpty())
-            setTextIfDifferent(tagText, state.tag.orEmpty())
-            setTextIfDifferent(contentText, state.content.orEmpty())
+            setTextIfDifferent(uidText, state.uid.orEmpty(), setUidText)
+            setTextIfDifferent(pidText, state.pid.orEmpty(), setPidText)
+            setTextIfDifferent(tidText, state.tid.orEmpty(), setTidText)
+            setTextIfDifferent(packageNameText, state.packageName.orEmpty(), setPackageNameText)
+            setTextIfDifferent(tagText, state.tag.orEmpty(), setTagText)
+            setTextIfDifferent(contentText, state.content.orEmpty(), setContentText)
 
             toolbar.menu.findItem(R.id.export_item).isVisible = state.filter != null
         }
@@ -250,9 +259,15 @@ internal class EditFilterFragment :
             .show()
     }
 
-    private fun setTextIfDifferent(textView: android.widget.EditText, text: String) {
+    // Updates the field only when the value actually changed, via the watcher-suppressing setter so a
+    // render doesn't register as a user edit. The guard also avoids needlessly moving the cursor.
+    private fun setTextIfDifferent(
+        textView: android.widget.EditText,
+        text: String,
+        setText: (CharSequence?) -> Unit,
+    ) {
         if (textView.text.toString() != text) {
-            textView.setText(text)
+            setText(text)
         }
     }
 }


### PR DESCRIPTION
Closes #248.

## Summary

The filter edit screen shows the "Discard changes?" dialog (added in #245) even when the user changed nothing.

`render()` pushes state into the fields via `setTextIfDifferent(...) → EditText.setText(...)`. That `setText` fires the field's `doAfterTextChanged` watcher, which sends an `Update…` command, and the reducer flips `isDirty = true` — so a pure render is mistaken for a user edit.

Because the watcher is attached on `onResume` / detached on `onPause` (`core/ui/base/.../TextViewExt.kt`), the spurious dirty reliably triggers after any onPause→onResume cycle (app switch, dialog, etc.) where a render runs with the watcher attached.

## Fix

`doAfterTextChanged` now returns a setter that detaches the watcher while applying a programmatic update, then restores the lifecycle's attachment state. `render()` uses that setter (via `setTextIfDifferent`) instead of `setText()`, so rendering state back into the form no longer looks like a user edit. Genuine typing still flows through the watcher unchanged.

This keeps the `isDirty`-in-reducer design and the TEA back-routing exactly as reviewed in #245 — only the programmatic-`setText` path is made watcher-safe.

## Test plan

- [x] `:core:ui:base` and `:feature:filters:presentation` compile clean.
- [x] On-device (SM-S948Q / Android 16): open a filter, touch nothing, back → no dialog.
- [x] Same but after an onPause→onResume cycle (home then resume) → still no dialog.
- [x] Make a real edit (toggle Including) then back → "Discard changes?" still appears; No keeps editing, Yes discards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)